### PR TITLE
[BE/FEAT] 유저 인가 처리 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### docker-compose.yml
 docker-compose.yml
+
+### config 외부 설정 폴더 ###
+/config-repo/

--- a/apigateway-service/.gitignore
+++ b/apigateway-service/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### .env
+.env

--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 //    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // jwt 의존성 추가
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/apigateway-service/src/main/java/org/example/apigatewayservice/filter/AuthorizationHeaderFilter.java
+++ b/apigateway-service/src/main/java/org/example/apigatewayservice/filter/AuthorizationHeaderFilter.java
@@ -1,0 +1,86 @@
+package org.example.apigatewayservice.filter;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.SecretKey;
+
+@Component
+@Slf4j
+public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
+
+    private final SecretKey key;
+
+    public AuthorizationHeaderFilter(@Value("${jwt.secret}") String secretKey) {
+        super(Config.class);
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public static class Config {
+
+    }
+
+    @Override
+    public GatewayFilter apply(AuthorizationHeaderFilter.Config config) {
+        // 여기에 필터로직 작성
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+
+            // 1. Authorization 헤더가 있는지 확인
+            if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+                return onError(exchange, "No authorization header", HttpStatus.UNAUTHORIZED);
+            }
+            // 2. 헤더에서 토큰 추출
+            String authorizationHeader = request.getHeaders().get(HttpHeaders.AUTHORIZATION).get(0);
+            String jwt = authorizationHeader.replace("Bearer ", "");
+
+            // 토큰에서 memberId 추출 & 유효성 검사
+            String memberId = getMemberId(jwt);
+            if (memberId == null) {
+                return onError(exchange, "JWT token is not valid", HttpStatus.UNAUTHORIZED);
+            }
+
+            // 요청 헤더에 memberId 추가
+            ServerHttpRequest newRequest = request.mutate()
+                    .header("X-USER-ID", memberId)
+                    .build();
+            // 다음 필터로 요청 넘김
+            return chain.filter(exchange);
+        };
+    }
+
+    // JWT를 파싱하여 memberId(subject)를 추출하는 메서드
+    private String getMemberId(String jwt) {
+        try {
+            Claims claims = Jwts.parserBuilder().setSigningKey(key).build()
+                    .parseClaimsJws(jwt).getBody();
+            return claims.getSubject();
+        } catch (Exception e) {
+            log.error("JWT Token is not valid", e);
+            return null;
+        }
+    }
+
+    // 에러 발생 시 클라이언트에게 오류 응답을 보내는 메서드
+    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(httpStatus);
+        log.error(err);
+        return  response.setComplete();
+    }
+}

--- a/apigateway-service/src/main/java/org/example/apigatewayservice/filter/AuthorizationHeaderFilter.java
+++ b/apigateway-service/src/main/java/org/example/apigatewayservice/filter/AuthorizationHeaderFilter.java
@@ -60,7 +60,7 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
                     .header("X-USER-ID", memberId)
                     .build();
             // 다음 필터로 요청 넘김
-            return chain.filter(exchange);
+            return chain.filter(exchange.mutate().request(newRequest).build());
         };
     }
 

--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
               predicates: Path=/apply/**
               filters:
                 - AuthorizationHeaderFilter
+            - id: member
+              uri: lb://MEMBER-SERVICE
+              predicates: Path=/members/**
+              filters:
+                - AuthorizationHeaderFilter
 eureka:
   client:
     service-url:

--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -24,12 +24,18 @@ spring:
             - id: recruit
               uri: lb://RECRUIT-SERVICE
               predicates: Path=/recruit/**
+              filters:
+                - AuthorizationHeaderFilter
             - id: alarm
               uri: lb://ALARM-SERVICE
               predicates: Path=/alarm/**
+              filters:
+                - AuthorizationHeaderFilter
             - id: apply
               uri: lb://RECRUIT-SERVICE
               predicates: Path=/apply/**
+              filters:
+                - AuthorizationHeaderFilter
 eureka:
   client:
     service-url:

--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -40,3 +40,8 @@ management:
     web:
       exposure:
         include: health,info,gateway
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-expire-time: 86400000
+  refresh-token-expire-time: 604800000

--- a/common/src/main/java/org/example/common/constant/GatewayConstant.java
+++ b/common/src/main/java/org/example/common/constant/GatewayConstant.java
@@ -1,0 +1,10 @@
+package org.example.common.constant;
+
+public final class GatewayConstant {
+
+    // private 생성자로 인스턴스화 방지
+    private GatewayConstant() {
+    }
+
+    public static final String GATEWAY_AUTH_HEADER = "X-USER-ID";
+}

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     config:
       server:
         native:
-          search-locations: classpath:/configs
+          search-locations: file:../config-service
 
 eureka:
   client:

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     config:
       server:
         native:
-          search-locations: file:../config-service
+          search-locations: classpath:/configs
 
 eureka:
   client:

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     config:
       server:
         native:
-          search-locations: file:../config-service
+          search-locations: file:../config-repo
 
 eureka:
   client:

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     config:
       server:
         native:
-          search-locations: file:../config-repo
+          search-locations: file:../config-service
 
 eureka:
   client:

--- a/member-service/src/main/java/org/example/memberservice/config/RedisConfig.java
+++ b/member-service/src/main/java/org/example/memberservice/config/RedisConfig.java
@@ -4,22 +4,30 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
-    @Value("${spring.data.redis.url}")
-    private String redisUrl;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        // application.yml에 있는 URL 정보를 파싱하여 Redis 호스트와 포트를 설정
-        String[] urlParts = redisUrl.replace("redis://", "").split(":");
-        String host = urlParts[0];
-        int port = Integer.parseInt(urlParts[1]);
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean

--- a/member-service/src/main/java/org/example/memberservice/config/RedisConfig.java
+++ b/member-service/src/main/java/org/example/memberservice/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package org.example.memberservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.url}")
+    private String redisUrl;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // application.yml에 있는 URL 정보를 파싱하여 Redis 호스트와 포트를 설정
+        String[] urlParts = redisUrl.replace("redis://", "").split(":");
+        String host = urlParts[0];
+        int port = Integer.parseInt(urlParts[1]);
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key와 Value의 Serializer를 String으로 설정합니다.
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/member-service/src/main/java/org/example/memberservice/controller/MemberController.java
+++ b/member-service/src/main/java/org/example/memberservice/controller/MemberController.java
@@ -1,26 +1,37 @@
 package org.example.memberservice.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.example.common.apiPayload.response.ApiResponse;
-import org.springframework.http.ResponseEntity;
+import org.example.common.constant.GatewayConstant;
+import org.example.memberservice.dto.MemberResponseDto;
+import org.example.memberservice.service.MemberService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
 
 @RestController
+@RequiredArgsConstructor
 public class MemberController {
-
+    private final MemberService memberService;
     /**
      * OAuth2 로그인 성공 후, JWT 토큰을 화면에 표시하기 위한 테스트용 API입니다.
      * @param accessToken 로그인 성공 핸들러가 쿼리 파라미터로 전달한 JWT
      * @return accessToken을 포함한 JSON 응답
      * 브라우저 화면에 보여주기 위한 임시 코드입니다
      */
-    @GetMapping("/login/success")
+/*    @GetMapping("/login/success")
     public ResponseEntity<Map<String, String>> loginSuccess(@RequestParam("accessToken") String accessToken){
         // 받은 accessToken을 JSON 형태로 감싸서 브라우저에 보여줍니다.
         return ResponseEntity.ok(Map.of("accessToken", accessToken));
-    }
+    }*/
 
+    /**
+     * 인가 테스트 API
+     */
+    @GetMapping("/members/me")
+    public ApiResponse<MemberResponseDto> getMyInfo(@RequestHeader(GatewayConstant.GATEWAY_AUTH_HEADER) Long memberId) {
+        MemberResponseDto myInfo = memberService.getMyInfo(memberId);
+        return ApiResponse.success("내 정보 조회 성공", "200", myInfo);
+    }
 }

--- a/member-service/src/main/java/org/example/memberservice/dto/MemberResponseDto.java
+++ b/member-service/src/main/java/org/example/memberservice/dto/MemberResponseDto.java
@@ -1,0 +1,24 @@
+package org.example.memberservice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.memberservice.domain.Member;
+
+@Getter
+@Builder
+public class MemberResponseDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String profileUrl;
+
+    // Member 엔티티를 DTO로 변환하는 정적 메서드
+    public static MemberResponseDto from(Member member) {
+        return MemberResponseDto.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .profileUrl(member.getProfileUrl())
+                .build();
+    }
+}

--- a/member-service/src/main/java/org/example/memberservice/jwt/JwtProvider.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/JwtProvider.java
@@ -13,25 +13,42 @@ import java.util.Date;
 @Component
 public class JwtProvider {
     public final Key key;
+    public final long accessTokenValiditySeconds;
+    public final long refreshTokenValiditySeconds;
 
     // application.yml에 설정된 secret key를 가져와서 HMAC-SHA 알고리즘에 맞는 Key 객체로 변환
-    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+    public JwtProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expire-time}") long accessTokenValidity,
+            @Value("${jwt.refresh-token-expire-time}") long refreshTokenValidity
+    ) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValiditySeconds = accessTokenValidity;
+        this.refreshTokenValiditySeconds = refreshTokenValidity;
     }
 
     // MemberID를 받아 AccessToken을 생성하는 메서드
     public String createAccessToken(String memberId) {
         long now = (new Date()).getTime();
         // token 만료 시간
-        long validityInMilliseconds = 1000 * 60 * 60 * 24 * 7;
-        Date validity = new Date(now + validityInMilliseconds);
+        Date validity = new Date(now + this.accessTokenValiditySeconds);
 
         return Jwts.builder()
                 .setSubject(memberId) // token의 주체로 MemberId를 설정
                 .signWith(key, SignatureAlgorithm.HS256)
                 .setExpiration(validity)
                 .compact();
+    }
 
+    // RefreshToken 생성
+    public String createRefreshToken() {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.refreshTokenValiditySeconds);
+
+        return Jwts.builder()
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(validity)
+                .compact();
     }
 }

--- a/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
@@ -30,7 +30,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
-    private final RedisTemplate<Object, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
 

--- a/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package org.example.memberservice.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,14 +11,17 @@ import org.example.common.apiPayload.error.exception.CustomException;
 import org.example.memberservice.domain.Member;
 import org.example.memberservice.repository.MemberRepository;
 import org.example.memberservice.security.OAuthAttributes;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -26,6 +30,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
+    private final RedisTemplate<Object, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
 
     @Override
@@ -40,21 +46,28 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             // DB에서 회원 정보 조회
             Member member = memberRepository.findBySocialId(attributes.getSocialId())
                     .orElseThrow(() -> new CustomException(BaseErrorCode._INTERNAL_SERVER_ERROR));// 일단 현재 코드를 사용하고 추후 common 라이브러리 코드 수정
-            String accessToken = jwtProvider.createAccessToken(String.valueOf(member.getId()));
+            String memberId = String.valueOf(member.getId());
+            String accessToken = jwtProvider.createAccessToken(memberId);
+            String refreshToken = jwtProvider.createRefreshToken(); // RefreshToken 생성
+
             log.info("발급된 Access Token: {}", accessToken);
+            log.info("발급된 Refresh Token: {}", refreshToken);
 
-            // 백엔드 테스트를 위해, API Gateway의 임의 경로로 토큰을 실어 리다이렉트합니다.
-            String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/login/success")
-                    .queryParam("accessToken", accessToken)
-                    .build()
-                    .encode(StandardCharsets.UTF_8)
-                    .toUriString();
+            redisTemplate.opsForValue().set(
+                    memberId,
+                    refreshToken,
+                    7, // 유효기간
+                    TimeUnit.DAYS // 단위는 일
+            );
 
-            log.info("테스트를 위해 다음 주소로 리다이렉트합니다: {}", targetUrl);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-            clearAuthenticationAttributes(request);
-            // 리다이렉트 실행
-            getRedirectStrategy().sendRedirect(request, response, targetUrl);
+            HashMap<Object, Object> tokens = new HashMap<>();
+            tokens.put("accessToken", accessToken);
+            tokens.put("refreshToken", refreshToken);
+
+            response.getWriter().println(objectMapper.writeValueAsString(tokens));
         } catch (Exception e) {
             log.error("로그인 성공 후 처리 중 에러 발생", e);
             throw e;

--- a/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
@@ -38,9 +38,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             OAuthAttributes attributes = OAuthAttributes.of("response", oAuth2User.getAttributes());
 
             // DB에서 회원 정보 조회
-            Member member = memberRepository.findByEmail(attributes.getEmail())
-                    .orElseThrow(() -> new CustomException(BaseErrorCode._INTERNAL_SERVER_ERROR)); // 일단 현재 코드를 사용하고 추후 common 라이브러리 코드 수정
-
+            Member member = memberRepository.findBySocialId(attributes.getSocialId())
+                    .orElseThrow(() -> new CustomException(BaseErrorCode._INTERNAL_SERVER_ERROR));// 일단 현재 코드를 사용하고 추후 common 라이브러리 코드 수정
             String accessToken = jwtProvider.createAccessToken(String.valueOf(member.getId()));
             log.info("발급된 Access Token: {}", accessToken);
 

--- a/member-service/src/main/java/org/example/memberservice/repository/MemberRepository.java
+++ b/member-service/src/main/java/org/example/memberservice/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findBySocialId(String socialId);
 }

--- a/member-service/src/main/java/org/example/memberservice/security/CustomOAuth2UserService.java
+++ b/member-service/src/main/java/org/example/memberservice/security/CustomOAuth2UserService.java
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     // DB에 사용자 정보가 없으면 새로 저장, 있으면 업데이트
     private Member saveOrUpdate(OAuthAttributes attributes) {
-        Member member = memberRepository.findByEmail(attributes.getEmail())
+        Member member = memberRepository.findBySocialId(attributes.getSocialId())
                 .map(entity -> entity.update(attributes.getName(), attributes.getProfileUrl())) // 이미 있는 회원이면 이름 업데이트 -> Why? 업데이트 사항이 있을때만 변경하면 되는거 아닌지. 아닐경우에는 그냥 조회만 해주면 되는거 아닌가
                 .orElse(attributes.toEntity());
         return memberRepository.save(member);

--- a/member-service/src/main/java/org/example/memberservice/service/MemberService.java
+++ b/member-service/src/main/java/org/example/memberservice/service/MemberService.java
@@ -1,0 +1,22 @@
+package org.example.memberservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.common.apiPayload.error.exception.CustomException;
+import org.example.memberservice.domain.Member;
+import org.example.memberservice.dto.MemberResponseDto;
+import org.example.memberservice.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MemberResponseDto getMyInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        return MemberResponseDto.from(member);
+    }
+}

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -50,7 +50,9 @@ spring:
 
   data:
     redis:
-      url: redis://localhost:6379
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
       timeout: 2000ms
       lettuce:
         pool:


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #21 

## ✅ 작업 내용
1. redis 추가했습니다
2. refreshToken 추가했습니다.
3. 인가 서비스 구현했습니다.

## 📸 스크린샷 (선택)
<img width="700" height="203" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/c3981f19-52a2-4d85-9eb2-7127d7c6d765" />

<img width="700" height="188" alt="image" src="https://github.com/user-attachments/assets/e40a95eb-84bb-46d9-8a3c-b17273cf2af7" />

<img width="488" height="476" alt="image" src="https://github.com/user-attachments/assets/8d628f3a-bb8d-4ce6-bd2f-d65c2e8cf251" />

## 👩‍💻 기타
1. 인가 테스트를 위해 멤버 조회 메서드를 구현했습니다. 확인 후 동일한 양식에 맞추어 진행하시면 됩니다.
2. ApiGateway와 member서비스 환경 변수를 노션에 추가해놓았습니다. 확인 부탁드립니다.
3. 멤버 인증시 기존 모놀리식 UserDetails를 받아오는 형식과 다르게 백엔드에서는 @RequestHeader(GatewayConstant.GATEWAY_AUTH_HEADER) Long memberId 과 같은 형식으로 요청합니다. 단, 해당 컨트롤러는 apiGateway를 거치면서 request가 변환되어 요청을 넘기기에 저런 형식이 나오는 것일 뿐, 테스트 시에는 accessToken을 사용해야 한다는 점 명심해주세요.
4. 참고로, 현재 네이버 로그인 테스트는 등록된 사용자만 가능합니다. 네이버 로그인 테스트 필요하신 분은 제게 ID/PW 보내주시면 됩니다.