### PR TITLE
[BE/FEAT] 회원 관리 api 구현

### DIFF
--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -25,6 +25,12 @@ spring:
               uri: lb://MEMBER-SERVICE
               predicates:
                 - Path=/auth/refresh
+            - id: member-auth
+              uri: lb://MEMBER-SERVICE
+              predicates:
+                - Path=/auth/**
+              filters:
+                - AuthorizationHeaderFilter
             - id: recruit
               uri: lb://RECRUIT-SERVICE
               predicates: Path=/recruit/**

--- a/member-service/src/main/java/org/example/memberservice/MemberServiceApplication.java
+++ b/member-service/src/main/java/org/example/memberservice/MemberServiceApplication.java
@@ -3,10 +3,12 @@ package org.example.memberservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication
 public class MemberServiceApplication {
 

--- a/member-service/src/main/java/org/example/memberservice/client/ChatClient.java
+++ b/member-service/src/main/java/org/example/memberservice/client/ChatClient.java
@@ -1,0 +1,12 @@
+package org.example.memberservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+//@FeignClient(name = "CHAT_SERVICE")
+public interface ChatClient {
+    @DeleteMapping("/chat/{memberId}")
+    void deleteAllChatDataByMemberId(@PathVariable("memberId") Long memberId);
+
+}

--- a/member-service/src/main/java/org/example/memberservice/client/RecruitClient.java
+++ b/member-service/src/main/java/org/example/memberservice/client/RecruitClient.java
@@ -4,10 +4,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "RECRUIT_SERVICE")
+@FeignClient(name = "RECRUIT-SERVICE")
 public interface RecruitClient {
 
     // recruit-service에 구현할 내부 API 엔드포인트
-    @DeleteMapping("/recruit/{memberId}")
+    @DeleteMapping("/recruit/by-member/{memberId}")
     void deleteAllRecruitDataByMemberId(@PathVariable("memberId") Long memberId);
 }

--- a/member-service/src/main/java/org/example/memberservice/client/RecruitClient.java
+++ b/member-service/src/main/java/org/example/memberservice/client/RecruitClient.java
@@ -1,0 +1,13 @@
+package org.example.memberservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "RECRUIT_SERVICE")
+public interface RecruitClient {
+
+    // recruit-service에 구현할 내부 API 엔드포인트
+    @DeleteMapping("/recruit/{memberId}")
+    void deleteAllRecruitDataByMemberId(@PathVariable("memberId") Long memberId);
+}

--- a/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
+++ b/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
@@ -25,4 +25,11 @@ public class AuthController {
         TokenRefreshResponse tokenRefreshResponse = authService.refreshTokens(request.getRefreshToken());
         return ApiResponse.success("토큰 재발급 성공", "TOKEN_REFRESH_SUCCESS", tokenRefreshResponse);
     }
+
+    @PostMapping("/logout")
+    public ApiResponse<MemberInfoDto> logout (
+            @RequestHeader(GatewayConstant.GATEWAY_AUTH_HEADER) Long memberId) {
+        MemberInfoDto memberInfoDto = authService.logout(memberId);
+        return ApiResponse.success("로그아웃 성공", "200", memberInfoDto);
+    }
 }

--- a/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
+++ b/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
@@ -32,4 +32,12 @@ public class AuthController {
         MemberInfoDto memberInfoDto = authService.logout(memberId);
         return ApiResponse.success("로그아웃 성공", "200", memberInfoDto);
     }
+
+    @PostMapping("/withdraw")
+    public ApiResponse<MemberInfoDto> withdraw(
+            @RequestHeader(GatewayConstant.GATEWAY_AUTH_HEADER) Long memberId
+    ) {
+        MemberInfoDto withdraw = authService.withdraw(memberId);
+        return ApiResponse.success("회원 탈퇴 성공", "200", withdraw);
+    }
 }

--- a/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
+++ b/member-service/src/main/java/org/example/memberservice/controller/AuthController.java
@@ -2,13 +2,12 @@ package org.example.memberservice.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.common.apiPayload.response.ApiResponse;
+import org.example.common.constant.GatewayConstant;
+import org.example.memberservice.dto.MemberInfoDto;
 import org.example.memberservice.dto.TokenRefreshRequest;
 import org.example.memberservice.dto.TokenRefreshResponse;
 import org.example.memberservice.service.AuthService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
+    @GetMapping
+    public ApiResponse<?> getMemberInfo(@RequestHeader(GatewayConstant.GATEWAY_AUTH_HEADER) Long memberId) {
+        MemberInfoDto memberInfo = authService.getMemberInfo(memberId);
+        return ApiResponse.success("사용자 정보 조회 성공", "200", memberInfo);
+    }
     @PostMapping("/refresh")
     public ApiResponse<TokenRefreshResponse> refreshToken(@RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse tokenRefreshResponse = authService.refreshTokens(request.getRefreshToken());

--- a/member-service/src/main/java/org/example/memberservice/domain/Member.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/Member.java
@@ -40,6 +40,12 @@ public class Member extends BaseEntity {
     @Column
     private Boolean ocrValidation;
 
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private PublicProfile publicProfile;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private MemberPreference memberPreference;
+
     @Builder
     public Member(String name, String email, String birthDate, String gender, String socialId, String profileUrl,Boolean isCompleted, Boolean ocrValidation) {
         this.name = name;

--- a/member-service/src/main/java/org/example/memberservice/domain/MemberPreference.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/MemberPreference.java
@@ -1,4 +1,21 @@
 package org.example.memberservice.domain;
 
-public class MemberPreference {
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPreference extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Member와의 일대일 관계 설정
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/member-service/src/main/java/org/example/memberservice/domain/MemberPreference.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/MemberPreference.java
@@ -1,0 +1,4 @@
+package org.example.memberservice.domain;
+
+public class MemberPreference {
+}

--- a/member-service/src/main/java/org/example/memberservice/domain/PublicProfile.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/PublicProfile.java
@@ -1,4 +1,20 @@
 package org.example.memberservice.domain;
 
-public class PublicProfile {
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublicProfile extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/member-service/src/main/java/org/example/memberservice/domain/PublicProfile.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/PublicProfile.java
@@ -1,0 +1,4 @@
+package org.example.memberservice.domain;
+
+public class PublicProfile {
+}

--- a/member-service/src/main/java/org/example/memberservice/domain/enums/Gender.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package org.example.memberservice.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE, NONE
+}

--- a/member-service/src/main/java/org/example/memberservice/domain/enums/LifeStyle.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/enums/LifeStyle.java
@@ -1,0 +1,5 @@
+package org.example.memberservice.domain.enums;
+
+public enum LifeStyle {
+    MORNING, EVENING
+}

--- a/member-service/src/main/java/org/example/memberservice/domain/enums/Personality.java
+++ b/member-service/src/main/java/org/example/memberservice/domain/enums/Personality.java
@@ -1,0 +1,5 @@
+package org.example.memberservice.domain.enums;
+
+public enum Personality {
+    INTROVERT, EXTROVERT
+}

--- a/member-service/src/main/java/org/example/memberservice/dto/MemberInfoDto.java
+++ b/member-service/src/main/java/org/example/memberservice/dto/MemberInfoDto.java
@@ -1,0 +1,31 @@
+package org.example.memberservice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.memberservice.domain.Member;
+
+@Builder
+@Getter
+public class MemberInfoDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String birthDate;
+    private String gender;
+    private String socialId;
+    private Boolean isCompleted;
+    private Boolean ocrValidation;
+
+    public static MemberInfoDto from(Member member) {
+        return MemberInfoDto.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .birthDate(member.getBirthDate())
+                .gender(member.getGender())
+                .socialId(member.getSocialId())
+                .isCompleted(member.getIsCompleted())
+                .ocrValidation(member.getOcrValidation())
+                .build();
+    }
+}

--- a/member-service/src/main/java/org/example/memberservice/jwt/JwtProvider.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/JwtProvider.java
@@ -65,7 +65,7 @@ public class JwtProvider {
         }
     }
 
-    private Claims getClaims(String token) {
+    public Claims getClaims(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)

--- a/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
+++ b/member-service/src/main/java/org/example/memberservice/jwt/OAuth2LoginSuccessHandler.java
@@ -48,7 +48,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                     .orElseThrow(() -> new CustomException(BaseErrorCode._INTERNAL_SERVER_ERROR));// 일단 현재 코드를 사용하고 추후 common 라이브러리 코드 수정
             String memberId = String.valueOf(member.getId());
             String accessToken = jwtProvider.createAccessToken(memberId);
-            String refreshToken = jwtProvider.createRefreshToken(memberId); // RefreshToken 생성
+            String refreshToken = jwtProvider.createRefreshToken(memberId); // RefreshToken 생성 <- 새로운 유저일 경우만 생성하는 것으로 수정해야함
 
             log.info("발급된 Access Token: {}", accessToken);
             log.info("발급된 Refresh Token: {}", refreshToken);

--- a/member-service/src/main/java/org/example/memberservice/repository/MemberPreferenceRepository.java
+++ b/member-service/src/main/java/org/example/memberservice/repository/MemberPreferenceRepository.java
@@ -1,0 +1,7 @@
+package org.example.memberservice.repository;
+
+import org.example.memberservice.domain.MemberPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPreferenceRepository extends JpaRepository<MemberPreference,Long> {
+}

--- a/member-service/src/main/java/org/example/memberservice/repository/PublicProfileRepository.java
+++ b/member-service/src/main/java/org/example/memberservice/repository/PublicProfileRepository.java
@@ -1,0 +1,7 @@
+package org.example.memberservice.repository;
+
+import org.example.memberservice.domain.PublicProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PublicProfileRepository extends JpaRepository<PublicProfile, Long> {
+}

--- a/member-service/src/main/java/org/example/memberservice/service/AuthService.java
+++ b/member-service/src/main/java/org/example/memberservice/service/AuthService.java
@@ -2,8 +2,11 @@ package org.example.memberservice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.memberservice.domain.Member;
+import org.example.memberservice.dto.MemberInfoDto;
 import org.example.memberservice.dto.TokenRefreshResponse;
 import org.example.memberservice.jwt.JwtProvider;
+import org.example.memberservice.repository.MemberRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 public class AuthService {
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
+    private final MemberRepository memberRepository;
 
     /**
      * RefreshToken을 받아서 새로운 AccessToken과 RefreshToken을 발급
@@ -55,5 +59,11 @@ public class AuthService {
                 newRefreshToken,
                 jwtProvider.refreshTokenValiditySeconds
         );
+    }
+
+    public MemberInfoDto getMemberInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("해당 멤버를 찾을 수 없습니다."));
+        return MemberInfoDto.from(member);
     }
 }

--- a/member-service/src/main/java/org/example/memberservice/service/AuthService.java
+++ b/member-service/src/main/java/org/example/memberservice/service/AuthService.java
@@ -3,6 +3,7 @@ package org.example.memberservice.service;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.memberservice.client.RecruitClient;
 import org.example.memberservice.domain.Member;
 import org.example.memberservice.dto.MemberInfoDto;
 import org.example.memberservice.dto.MemberResponseDto;
@@ -23,7 +24,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
     private final MemberRepository memberRepository;
-
+    private final RecruitClient recruitClient;
     /**
      * RefreshToken을 받아서 새로운 AccessToken과 RefreshToken을 발급
      * RTR(Refresh Token Rotation) 전략을 사용하여 매번 새로운 RefreshToken을 발급
@@ -78,6 +79,27 @@ public class AuthService {
                 .orElseThrow(() -> new RuntimeException("Member not found"));
 
         return MemberInfoDto.from(member);
+    }
 
+    @Transactional
+    public MemberInfoDto withdraw(Long memberId) {
+        // 1. 삭제할 회원 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        MemberInfoDto responseDto = MemberInfoDto.from(member);
+        // 2. 다른 서비스에 회원 데이터 삭제 요청 (오케스트레이션)
+        log.info("Recruit-service에 회원 데이터 삭제 요청 시작 - memberId: {}", memberId);
+        recruitClient.deleteAllRecruitDataByMemberId(memberId);
+        log.info("Recruit-service 회원 데이터 삭제 완료");
+        // chatClient.deleteAllChatDataByMemberId(memberId); - 추후 chat 서비스 구현 시 업데이트 필요
+
+        // 3. Redis에서 RefreshToken 삭제
+        redisTemplate.delete(String.valueOf(memberId));
+
+        // 4. DB에서 회원 정보 삭제
+        memberRepository.delete(member);
+
+        log.info("회원 탈퇴 최종 완료 - memberId: {}", memberId);
+        return responseDto;
     }
 }

--- a/member-service/src/main/java/org/example/memberservice/service/AuthService.java
+++ b/member-service/src/main/java/org/example/memberservice/service/AuthService.java
@@ -1,9 +1,11 @@
 package org.example.memberservice.service;
 
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.memberservice.domain.Member;
 import org.example.memberservice.dto.MemberInfoDto;
+import org.example.memberservice.dto.MemberResponseDto;
 import org.example.memberservice.dto.TokenRefreshResponse;
 import org.example.memberservice.jwt.JwtProvider;
 import org.example.memberservice.repository.MemberRepository;
@@ -11,6 +13,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -65,5 +68,16 @@ public class AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("해당 멤버를 찾을 수 없습니다."));
         return MemberInfoDto.from(member);
+    }
+
+    public MemberInfoDto logout(Long memberId) {
+        // Redis에서 RefreshToken 삭제
+        redisTemplate.delete(String.valueOf(memberId));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        return MemberInfoDto.from(member);
+
     }
 }

--- a/recruit-service/src/main/java/org/example/recruitservice/controller/RecruitController.java
+++ b/recruit-service/src/main/java/org/example/recruitservice/controller/RecruitController.java
@@ -54,7 +54,7 @@ public class RecruitController {
     }
 
 
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping("/by-member/{memberId}")
     public ResponseEntity<Void> deleteAllRecruitDataByMemberId(@PathVariable("memberId") Long memberId){
         recruitService.deleteAllRecruitData(memberId);
         applyService.deleteAllApplyData(memberId);

--- a/recruit-service/src/main/java/org/example/recruitservice/controller/RecruitController.java
+++ b/recruit-service/src/main/java/org/example/recruitservice/controller/RecruitController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.recruitservice.dto.RecruitCoreResponse;
 import org.example.recruitservice.dto.RecruitRequest;
 import org.example.recruitservice.dto.RecruitResponse;
+import org.example.recruitservice.service.ApplyService;
 import org.example.recruitservice.service.RecruitService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecruitController {
     private final RecruitService recruitService;
+    private final ApplyService applyService;
 
     @GetMapping("/test")
     public ResponseEntity<String> recruit() {
@@ -51,4 +53,11 @@ public class RecruitController {
         return ResponseEntity.ok(recruitService.deleteRecruitPost(postId));
     }
 
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> deleteAllRecruitDataByMemberId(@PathVariable("memberId") Long memberId){
+        recruitService.deleteAllRecruitData(memberId);
+        applyService.deleteAllApplyData(memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/recruit-service/src/main/java/org/example/recruitservice/service/ApplyService.java
+++ b/recruit-service/src/main/java/org/example/recruitservice/service/ApplyService.java
@@ -85,4 +85,10 @@ public class ApplyService {
         Optional<ApplyRecord> apply = applyRepository.findApplyRecordsByAppliedMemberIdAndPostId(postId, memberId);
         return apply.isPresent();
     }
+
+    public void deleteAllApplyData(Long memberId) {
+        // 해당 멤버의 모든 지원 기록을 찾아서 삭제
+        List<ApplyRecord> records = applyRepository.findApplyRecordsByAppliedMemberId(memberId);
+        applyRepository.deleteAll(records);
+    }
 }

--- a/recruit-service/src/main/java/org/example/recruitservice/service/RecruitService.java
+++ b/recruit-service/src/main/java/org/example/recruitservice/service/RecruitService.java
@@ -80,4 +80,10 @@ public class RecruitService {
             return "구인글 삭제 불가능";
         }
     }
+
+    public void deleteAllRecruitData(Long memberId) {
+        // 해당 멤버가 작성한 모든 구인글을 찾아서 삭제
+        List<RecruitPost> posts = recruitRepository.findAllByOwnerId(memberId);
+        recruitRepository.deleteAll(posts);
+    }
 }


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #26 

## ✅ 작업 내용
1. refreshToken 재발급 구현 완료
2. 로그아웃 구현 완료
3. 회원 탈퇴 구현 완료

## 📸 스크린샷 (선택)

## 👩‍💻 기타
1. 로그아웃이나 회원 탈퇴의 경우 프론트에서 accessToken을 제거해주어야 합니다.
2. 회원탈퇴 네이버 연동 해제 api호출은 프론트에서 구현되어야 합니다.
3. 멤버 삭제를 위해 recruitController와 service로직을 추가하였습니다.
4. Chat서비스는 아직 미완 상태이기에 추후 구현 시 회원 탈퇴 로직 또한 수정해 주어야 합니다.
5. response가 수정된 api들이 있으므로 노션에 올려진 api 명세서를 확인해주세요.